### PR TITLE
Merge prior shoot straight and spin for L1

### DIFF
--- a/rio/subsystems/cannon/constants_cannon.py
+++ b/rio/subsystems/cannon/constants_cannon.py
@@ -1,22 +1,20 @@
-from phoenix5 import TalonSRX, TalonSRXConfiguration, TalonSRXControlMode, SupplyCurrentLimitConfiguration
-from wpilib import DigitalInput
+from phoenix5 import SupplyCurrentLimitConfiguration
+
 
 class Constants_Cannon:
 
     leftMotorID = 14
     rightMotorID = 15
-    digitalInputID = 0
 
     current_limit = 40
     current_threshold = 60
     current_threshold_time = 3.0
-    
 
-    supply_config = SupplyCurrentLimitConfiguration(True, current_limit, current_threshold, current_threshold_time)
+    supply_config = SupplyCurrentLimitConfiguration(
+        True, current_limit, current_threshold, current_threshold_time
+    )
 
-    
-
-
-
-    
-
+    loadPercentOutput = 0.5
+    placePercentOutput = 0.75
+    backupPercentOutput = -0.3
+    placeCoralAutoTimeoutSec = 1.0


### PR DESCRIPTION
 - Found my original code that worked well with the prototype.
 - Aligned the API with the current dev branch code so no other code would need to change
 - Aligned naming conventions.
 - Aligned motor inversion to the current dev stream. My original had them the other way. Check this.
 - Cleaned up dashboard.
 - Rewrote coral loaded tracking to explicit sets rather than toggle. This could be moved to robot state. Also, loaded initialized to true since we will start each match loaded.
 - Added time place commands for auto modes.
 - See the _runSpec method and its callers to see how the left and right sides are balanced. The balancing constants will probably need adjusted for the current canon.