### PR TITLE
Add basic RobotState

### DIFF
--- a/rio/robotstate.py
+++ b/rio/robotstate.py
@@ -1,0 +1,12 @@
+class RobotState:
+    
+    coralInCannon = True
+
+    def __new__(cls):
+        if not hasattr(cls, "instance"):
+            cls.instance = super(RobotState, cls).__new__(cls)
+        
+        return cls.instance
+    
+    def setCoralInCannon(newCoralInCannon : bool):
+        RobotState.coralInCannon = newCoralInCannon


### PR DESCRIPTION
Adds a basic robotstate class based on the original [robotstate](https://github.com/RoboEagles4828/phyto2025/tree/robotstate) branch that has one state: if the coral is in the cannon.

Supercedes #8 